### PR TITLE
CloudFormation deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .mypy_cache
 .pytest_cache
 dist
+*.packaged.yml
+.direnv

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,47 @@
+NAME := process-cloudfront-logs
+ENV := staging
+
+FUNCTION := $(NAME)-$(ENV)
+
+ifeq ($(ENV), production)
+REGION = us-east-1
+SRC_BUCKET := process-cloudfront-logs-in
+DST_BUCKET := process-cloudfront-logs-out
+else
+REGION = eu-west-1
+SRC_BUCKET := doist-alb-logs
+DST_BUCKET := doist-alb-logs-processed
+endif
+
+.PHONY: help artifacts deploy delete
+.DEFAULT_GOAL := help
+
+help:           ## Show this help.
+	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sed -e 's/##//'
+
+clean:
+	rm -f cloudformation.packaged.yml
+
+artifacts:    ## Create S3 bucket for lambda artifacts
+	aws s3 ls s3://$(FUNCTION)-lambda --region $(REGION) \
+		|| aws s3 mb s3://$(FUNCTION)-lambda --region $(REGION)
+
+cloudformation.packaged.yml: cloudformation.yml process.py artifacts
+	aws cloudformation package --region $(REGION) \
+		--template-file cloudformation.yml \
+		--output-template-file cloudformation.packaged.yml \
+		--s3-bucket $(FUNCTION)-lambda
+
+deploy: cloudformation.packaged.yml ## Deploy
+	aws cloudformation deploy --region $(REGION) \
+		--template-file cloudformation.packaged.yml \
+		--stack-name $(FUNCTION)-lambda \
+		--capabilities CAPABILITY_NAMED_IAM \
+		--parameter-overrides \
+			Environment=$(ENV) \
+			Source=$(SRC_BUCKET) \
+			Results=$(DST_BUCKET)
+
+delete:         ## Delete all created AWS resources  (DENGEROUS!)
+#	aws cloudformation delete-stack --region $(REGION) \
+#		--stack-name $(FUNCTION)-lambda

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ poetry run pytest
 - Deploy a new lambda function by running `make deploy` or `make ENV=production deploy`. The default environment is staging. The command creates a lambda function and all required resources. Please see the [CloudFormation template](./cloudformation.yml) for details.
 - Test if the function works as expected. For the valid input, it has to create a new object in the destination S3 bucket.
 
+## Deploing a new version
+
+To deploy a new version of the function run `make deploy` again or `make ENV=production deploy` for production environment.
+
 ## Making it usable for Athena
 
 To make it usable for AWS Athena, once some JSON files are created, create a new AWS Glue Crawler to process the content, and make it run daily to collect new partitions.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Process S3 logs from CloudFront
 
-Process CloudFront logs to convert them from custom CSV format to JSON-encoded, merging date and time fields into a single datetime object.
+Process CloudFront logs to convert them from custom CSV format to JSON-encoded, merging date and time fields into a single date-time object.
 
 ## Necessary environment
 
@@ -12,25 +12,26 @@ Process CloudFront logs to convert them from custom CSV format to JSON-encoded, 
   - Read permissions for the S3 bucket with logs to read the content of the source key.
   - Write permissions for the `S3_DEST_BUCKET` to write the modified file.
 
+Please see detailed IAM policies in the [CloudFormation template](./cloudformation.yml).
+
 ## Testing locally
 
 Create a Poetry project.
 
-```
+```sh
 poetry install
 ```
 
 Run tests:
 
-```
+```sh
 poetry run pytest
 ```
 
 ## Installing to make it work
 
 - Create a new S3 bucket to store the results of the processing.
-- Create a new lambda function, set necessary permissions, set environment variable `S3_DEST_BUCKET`.
-- Create a trigger S3, event type "ObjectCreated", and connect it to the lambda function.
+- Deploy a new lambda function by running `make deploy` or `make ENV=production deploy`. The default environment is staging. The command creates a lambda function and all required resources. Please see the [CloudFormation template](./cloudformation.yml) for details.
 - Test if the function works as expected. For the valid input, it has to create a new object in the destination S3 bucket.
 
 ## Making it usable for Athena
@@ -49,7 +50,7 @@ The script has two modes: "print" or "index". The print mode is a "dry run" mode
 
 Print to stdout all S3 keys with CloudFront logs for 16 July 2020.
 
-```
+```sh
 poetry run ./scripts/process_all.py \
     --bucket=cloudfront-logs \
     --action=print \
@@ -59,7 +60,7 @@ poetry run ./scripts/process_all.py \
 
 Index the contents of 16 July 2020 asynchronously.
 
-```
+```sh
 poetry run ./scripts/process_all.py \
     --bucket=cloudfront-logs \
     --action=index \

--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -1,0 +1,165 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: >
+  Create an Amazon S3 notification configuration for Lambda on an existing S3 bucket.
+  Please see for details https://amzn.to/39qSPKC
+Parameters:
+  Source:
+    Type: String
+    Default: process-cloudfront-logs-in
+    Description: Source S3 bucket
+  Results:
+    Type: String
+    Default: process-cloudfront-logs-out
+    Description: Destination S3 bucket.
+  FunctionName:
+    Type: String
+    Default: process-cloudfront-logs
+    Description: A name for a lambda function.
+  Environment:
+    Type: String
+    Default: staging
+    AllowedValues:
+      - staging
+      - production
+    Description: Deployment environment (staging or production).
+
+Resources:
+  ProcessLambdaFunction:
+    Type: "AWS::Lambda::Function"
+    Properties:
+      FunctionName: !Sub "${FunctionName}-${Environment}"
+      Role: !GetAtt LambdaRole.Arn
+      Handler: process.lambda_handler
+      Runtime: python3.8
+      MemorySize: 128
+      Timeout: 300
+      Code: process.py
+      Environment:
+        Variables:
+          S3_DEST_BUCKET: !Ref Results
+
+  LambdaInvokePermission:
+    Type: "AWS::Lambda::Permission"
+    Properties:
+      FunctionName: !GetAtt ProcessLambdaFunction.Arn
+      Action: "lambda:InvokeFunction"
+      Principal: s3.amazonaws.com
+      SourceAccount: !Ref "AWS::AccountId"
+      SourceArn: !Sub "arn:aws:s3:::${Source}"
+
+  LambdaRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      RoleName: !Sub "${FunctionName}-${Environment}-lambda-role"
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - "sts:AssumeRole"
+      Path: /
+      Policies:
+        - PolicyName: root
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "s3:GetBucketNotification"
+                  - "s3:PutBucketNotification"
+                Resource: !Sub "arn:aws:s3:::${Source}"
+              - Effect: Allow
+                Action: s3:PutObject
+                Resource:
+                  - !Sub "arn:aws:s3:::${Results}/*"
+              - Effect: Allow
+                Action: s3:GetObject
+                Resource:
+                  - !Sub "arn:aws:s3:::${Source}/*"
+              - Effect: Allow
+                Action:
+                  - "logs:CreateLogGroup"
+                  - "logs:CreateLogStream"
+                  - "logs:PutLogEvents"
+                Resource: "arn:aws:logs:*:*:*"
+
+  CustomResourceLambdaFunction:
+    Type: "AWS::Lambda::Function"
+    Properties:
+      Handler: index.lambda_handler
+      Role: !GetAtt LambdaRole.Arn
+      Code:
+        ZipFile: |
+
+          from __future__ import print_function
+          import json
+          import boto3
+          import cfnresponse
+
+          SUCCESS = "SUCCESS"
+          FAILED = "FAILED"
+
+          print('Loading function')
+          s3 = boto3.resource('s3')
+
+          def lambda_handler(event, context):
+              print("Received event: " + json.dumps(event, indent=2))
+              responseData={}
+              try:
+                  if event['RequestType'] == 'Delete':
+                      print("Request Type:",event['RequestType'])
+                      Bucket=event['ResourceProperties']['Bucket']
+                      delete_notification(Bucket)
+                      print("Sending response to custom resource after Delete")
+                  elif event['RequestType'] == 'Create' or event['RequestType'] == 'Update':
+                      print("Request Type:",event['RequestType'])
+                      LambdaArn=event['ResourceProperties']['LambdaArn']
+                      Bucket=event['ResourceProperties']['Bucket']
+                      add_notification(LambdaArn, Bucket)
+                      responseData={'Bucket':Bucket}
+                      print("Sending response to custom resource")
+                  responseStatus = 'SUCCESS'
+              except Exception as e:
+                  print('Failed to process:', e)
+                  responseStatus = 'FAILURE'
+                  responseData = {'Failure': 'Something bad happened.'}
+              cfnresponse.send(event, context, responseStatus, responseData)
+
+          def add_notification(LambdaArn, Bucket):
+              bucket_notification = s3.BucketNotification(Bucket)
+              response = bucket_notification.put(
+                NotificationConfiguration={
+                  'LambdaFunctionConfigurations': [
+                    {
+                        'LambdaFunctionArn': LambdaArn,
+                        'Events': ['s3:ObjectCreated:*'],
+                        "Filter": {
+                            "Key": {
+                                "FilterRules": [{"Name": "prefix", "Value": "cf-logs/"},]
+                            }
+                        }
+                    }
+                  ]
+                }
+              )
+              print("Put request completed....")
+
+          def delete_notification(Bucket):
+              bucket_notification = s3.BucketNotification(Bucket)
+              response = bucket_notification.put(
+                  NotificationConfiguration={}
+              )
+              print("Delete request completed....")
+      Runtime: python3.6
+      Timeout: 50
+
+  LambdaTrigger:
+    Type: "Custom::LambdaTrigger"
+    DependsOn: LambdaInvokePermission
+    Properties:
+      ServiceToken: !GetAtt CustomResourceLambdaFunction.Arn
+      LambdaArn: !GetAtt ProcessLambdaFunction.Arn
+      Bucket: !Ref Source


### PR DESCRIPTION
* CloudFromation template
* Makefile automation 

Adding an S3 notification configuration for Lambda on an **existing** S3 bucket is a bit non-intuitive. CloudFormation keeps a state of all resources. It only can't keep track of resources *outside* of a stack. Because of that, this use case is not directly supported neither in AWS SAM nor in CloudFormation. 

However, there is a workaround https://aws.amazon.com/premiumsupport/knowledge-center/cloudformation-s3-notification-lambda/ 

Staging deployment: `process-cloudfront-logs-staging-lambda`

Side note: 

`python 3.8` runtime for lambda function has some limitations; for example, [ZipFile](https://github.com/aws-cloudformation/aws-cloudformation-coverage-roadmap/issues/80) does not work. It probably can't be recommended for production yet. 
